### PR TITLE
fix(thumbnails): adapt csp to fix thumbnails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "webpack-cli": "6.0.1"
       },
       "engines": {
-        "vscode": "^1.58.1"
+        "vscode": "^1.96.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/src/pdf_viewer_provider.ts
+++ b/src/pdf_viewer_provider.ts
@@ -132,7 +132,7 @@ export class PDFViewerProvider implements CustomReadonlyEditorProvider {
         /* html */ `<title>PDF.js viewer</title>`,
         /* html */
         `
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src ${cspSource}; script-src 'unsafe-inline' ${cspSource}; worker-src blob: ${cspSource}; style-src 'unsafe-inline' ${cspSource}; img-src * ${cspSource}">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src ${cspSource}; script-src 'unsafe-inline' ${cspSource}; worker-src blob: ${cspSource}; style-src 'unsafe-inline' ${cspSource}; img-src * ${cspSource} data:;">
 <meta id="pdf-view-config" data-config="${escapeAttribute(settings)}">
 
 <title>PDF.js viewer</title>


### PR DESCRIPTION
In version 0.1.2 thumbnails do not load because CSP disallows arbitrary base64 data images. This PR now allows arbitrary data images in viewer.
Before:
![image](https://github.com/user-attachments/assets/3b38591d-b649-4eaf-b4f8-4abf1495b9b2)
Console error: 
```
Refused to load the image 'data:image/png;base64,iVBgetqSt+LK+rW0zDAAAAABJRU5ErkJggg==' because it violates the following Content Security Policy directive: "img-src * 'self' https://*.vscode-cdn.net". Note that '*' matches only URLs with network schemes ('http', 'https', 'ws', 'wss'), or URLs whose scheme matches `self`'s scheme. The scheme 'data:' must be added explicitly.
```
After:
![image](https://github.com/user-attachments/assets/f948b2ae-bb7e-445d-b3d5-adeeee1ab4c4)


