### PR TITLE
feat(dark mode): add dark mode by css invert.

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -17,3 +17,8 @@
 body {
   padding: 0;
 }
+
+/* Dark Mode Filter: Invert color of PDF pages only */
+.pdf-dark-mode .page {
+    filter: invert(1) hue-rotate(180deg);
+}

--- a/assets/main.mjs
+++ b/assets/main.mjs
@@ -31,6 +31,11 @@ PDFViewerApplicationOptions.set("disablePreferences", true);
 
 void (async () => {
   await window.PDFViewerApplication.initializedPromise;
+
+  if (config.darkMode) {
+      document.body.classList.add("pdf-dark-mode");
+  }
+
   await window.PDFViewerApplication.open(config);
   const [,hash] = config.url.split("#")
   if(hash){
@@ -39,6 +44,15 @@ void (async () => {
 })();
 
 window.addEventListener("message", async (event) => {
+  if (event.data.type === 'update-theme') {
+    if (event.data.darkMode) {
+        document.body.classList.add("pdf-dark-mode");
+    } else {
+        document.body.classList.remove("pdf-dark-mode");
+    }
+    return;
+  }
+
   await window.PDFViewerApplication.initializedPromise;
   const currentPageNumber =
     window.PDFViewerApplication.pdfViewer.currentPageNumber;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,17 @@
           }
         ]
       }
-    ]
+    ],
+    "configuration": {
+      "title": "PDF Viewer",
+      "properties": {
+        "pdf.enableDarkMode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable Dark Mode for PDF Viewer (inverts colors of the page)."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,11 +14,38 @@
  * limitations under the License.
  */
 
-import type { ExtensionContext } from "vscode";
+import { type ExtensionContext, window, commands, workspace, StatusBarAlignment } from "vscode";
 import { PDFViewerProvider } from "./pdf_viewer_provider";
 
 export function activate(context: ExtensionContext): void {
   context.subscriptions.push(PDFViewerProvider.register(context));
+
+  // Add Status Bar Item for Dark Mode
+  const darkModeStatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
+  darkModeStatusBarItem.command = "pdf.toggleDarkMode";
+  darkModeStatusBarItem.tooltip = "Toggle PDF Dark Mode";
+  context.subscriptions.push(darkModeStatusBarItem);
+
+  const updateStatusBar = () => {
+    const enabled = workspace.getConfiguration("pdf").get<boolean>("enableDarkMode", false);
+    darkModeStatusBarItem.text = enabled ? "$(moon) PDF Dark" : "$(sun) PDF Light";
+    darkModeStatusBarItem.show();
+  };
+
+  context.subscriptions.push(workspace.onDidChangeConfiguration(e => {
+      if (e.affectsConfiguration("pdf.enableDarkMode")) {
+          updateStatusBar();
+      }
+  }));
+
+  updateStatusBar();
+
+  // Register Toggle Command
+  context.subscriptions.push(commands.registerCommand("pdf.toggleDarkMode", async () => {
+      const config = workspace.getConfiguration("pdf");
+      const current = config.get<boolean>("enableDarkMode", false);
+      await config.update("enableDarkMode", !current, true); // true = updates in Global settings
+  }));
 }
 
 export function deactivate() {}

--- a/src/pdf_viewer_provider.ts
+++ b/src/pdf_viewer_provider.ts
@@ -24,6 +24,7 @@ import {
   type WebviewPanel,
   window,
   commands,
+  workspace,
 } from "vscode";
 
 import rawViewerHtml from "../assets/pdf.js/web/viewer.html";
@@ -68,6 +69,18 @@ export class PDFViewerProvider implements CustomReadonlyEditorProvider {
 
   constructor(context: ExtensionContext) {
     this.extensionRoot = Uri.file(context.extensionPath);
+
+    workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration("pdf.enableDarkMode")) {
+            const enabled = workspace.getConfiguration("pdf").get<boolean>("enableDarkMode", false);
+            for (const webviewPanel of this.webviews.getAll()) {
+                webviewPanel.webview.postMessage({
+                    type: "update-theme",
+                    darkMode: enabled
+                });
+            }
+        }
+    });
   }
 
   async openCustomDocument(uri: Uri) {
@@ -121,7 +134,7 @@ export class PDFViewerProvider implements CustomReadonlyEditorProvider {
             const [file, hash] = urlWithCdnScheme.substring(vscodeWebviewUriPrefix.length).split("#")
             commands.executeCommand("vscode.open", Uri.file(file!).with({fragment: hash ?? ""}))
         }
-    })
+    });
   }
 
   private getHtmlForWebview(document: PDFDocument, webview: Webview): string {
@@ -132,10 +145,12 @@ export class PDFViewerProvider implements CustomReadonlyEditorProvider {
       resolveUri("assets", "pdf.js", ...paths);
 
     const cspSource = webview.cspSource;
+    const darkMode = workspace.getConfiguration("pdf").get<boolean>("enableDarkMode", false);
 
     const settings = {
       url: `${webview.asWebviewUri(document.uri)}`,
       docBaseUrl: `${webview.asWebviewUri(document.uri)}`,
+      darkMode: darkMode
     };
 
     return viewerHtml

--- a/src/webview_collection.ts
+++ b/src/webview_collection.ts
@@ -33,6 +33,12 @@ export class WebviewCollection {
     }
   }
 
+  public *getAll(): Iterable<WebviewPanel> {
+    for (const entry of this._webviews) {
+        yield entry.webviewPanel;
+    }
+  }
+
   /** Add a new webview to the collection. */
   public add(uri: Uri, webviewPanel: WebviewPanel) {
     const entry = { resource: uri.toString(), webviewPanel };


### PR DESCRIPTION
I've inplemented a dark mode for pdf viewer with a button swicher on the tab bar by using css invert.
**NOTE: This inplementation is designed for pure text document ,there may be some horible effects when inverting pictures(like selfies).**

<img width="2123" height="1336" alt="image" src="https://github.com/user-attachments/assets/375823a1-a031-4f2f-92bb-7e29815eebc0" />
