### PR TITLE
fix: resolve VSIX glob path before publishing extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,14 +107,17 @@ jobs:
         with:
           name: release-assets
           path: dist
+      - name: Find VSIX file
+        id: find-vsix
+        run: echo "path=$(ls dist/*.vsix)" >> $GITHUB_OUTPUT
       - name: Publish to Open VSX
         uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          extensionFile: dist/*.vsix
+          extensionFile: ${{ steps.find-vsix.outputs.path }}
       - name: Publish to VS Marketplace
         uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: dist/*.vsix
+          extensionFile: ${{ steps.find-vsix.outputs.path }}


### PR DESCRIPTION
## Summary
- Add a "Find VSIX file" step to resolve the actual `.vsix` filename before passing it to `HaaLeo/publish-vscode-extension`
- The action does not support glob patterns in `extensionFile`, causing `ENOENT: no such file or directory, open 'dist/*.vsix'`

## Test plan
- [ ] Merge and retag v0.1.7 to verify the publish jobs succeed