### PR TITLE
feat: zoom, sidebar, Ctrl+P, drag crash

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -1,12 +1,12 @@
 /*
  * Copyright 2021 Mathematic, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/assets/main.mjs
+++ b/assets/main.mjs
@@ -28,10 +28,36 @@ const config = loadConfig();
 
 PDFViewerApplicationOptions.set("defaultUrl", "");
 PDFViewerApplicationOptions.set("disablePreferences", true);
+PDFViewerApplicationOptions.set(
+  "defaultZoomValue",
+  config.defaultZoomValue ?? "auto"
+);
+PDFViewerApplicationOptions.set(
+  "sidebarViewOnLoad",
+  config.sidebarViewOnLoad ?? 0
+);
+
+// Prevent pdf.js from intercepting Ctrl+P/Cmd+P and triggering the print dialog.
+document.addEventListener(
+  "keydown",
+  (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === "p") {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    }
+  },
+  true
+);
+
+// Track whether the initial load has completed so that minor post-load
+// runtime errors don't replace the viewer with a crash screen.
+let loaded = false;
 
 void (async () => {
   await window.PDFViewerApplication.initializedPromise;
   await window.PDFViewerApplication.open(config);
+  await window.PDFViewerApplication.pdfViewer.pagesPromise;
+  loaded = true;
   const [, hash] = config.url.split("#");
   if (hash) {
     window.PDFViewerApplication.pdfLinkService.setHash(
@@ -46,8 +72,10 @@ window.addEventListener("message", async (event) => {
     window.PDFViewerApplication.pdfViewer.currentPageNumber;
   switch (event.data.action) {
     case "reload":
+      loaded = false;
       await window.PDFViewerApplication.open(config);
       await window.PDFViewerApplication.pdfViewer.pagesPromise;
+      loaded = true;
       window.PDFViewerApplication.pdfViewer.currentPageNumber = Math.min(
         currentPageNumber,
         window.PDFViewerApplication.pdfViewer.pagesCount
@@ -57,7 +85,7 @@ window.addEventListener("message", async (event) => {
 });
 
 window.addEventListener("error", (error) => {
-  const msg = document.createElement("body");
-  msg.innerText = `An error occurred (${error.message}) while loading the file. Please open it again. `;
-  document.body = msg;
+  if (!loaded) {
+    document.body.textContent = `An error occurred (${error.message}) while loading the file. Please open it again.`;
+  }
 });

--- a/package.json
+++ b/package.json
@@ -38,7 +38,65 @@
           }
         ]
       }
-    ]
+    ],
+    "configuration": {
+      "title": "PDF",
+      "type": "object",
+      "properties": {
+        "pdf.defaultZoomValue": {
+          "type": "string",
+          "default": "auto",
+          "scope": "resource",
+          "enum": [
+            "auto",
+            "page-actual",
+            "page-fit",
+            "page-width",
+            "50",
+            "75",
+            "100",
+            "125",
+            "150",
+            "200"
+          ],
+          "enumDescriptions": [
+            "Automatic",
+            "Actual size",
+            "Fit page",
+            "Fit width",
+            "50%",
+            "75%",
+            "100%",
+            "125%",
+            "150%",
+            "200%"
+          ],
+          "description": "Default zoom level when opening a PDF."
+        },
+        "pdf.sidebarViewOnLoad": {
+          "type": "number",
+          "default": 0,
+          "scope": "resource",
+          "enum": [
+            -1,
+            0,
+            1,
+            2,
+            3,
+            4
+          ],
+          "enumDescriptions": [
+            "Restore previous state",
+            "None",
+            "Thumbnails",
+            "Outline",
+            "Attachments",
+            "Layers"
+          ],
+          "description": "Sidebar panel to show when opening a PDF."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "pnpm run package",

--- a/src/pdf-viewer-provider.ts
+++ b/src/pdf-viewer-provider.ts
@@ -24,6 +24,7 @@ import {
   type Webview,
   type WebviewPanel,
   window,
+  workspace,
 } from "vscode";
 
 import rawViewerHtml from "../assets/pdf.js/web/viewer.html";
@@ -137,9 +138,12 @@ export class PDFViewerProvider implements CustomReadonlyEditorProvider {
 
     const cspSource = webview.cspSource;
 
+    const config = workspace.getConfiguration("pdf");
     const settings = {
       url: `${webview.asWebviewUri(document.uri)}`,
       docBaseUrl: `${webview.asWebviewUri(document.uri)}`,
+      defaultZoomValue: config.get<string>("defaultZoomValue", "auto"),
+      sidebarViewOnLoad: config.get<number>("sidebarViewOnLoad", 0),
     };
 
     return viewerHtml


### PR DESCRIPTION
## Summary

- **#11** — Add `pdf.defaultZoomValue` setting (`auto`, `page-actual`, `page-fit`, `page-width`, or a percentage)
- **#22** — Add `pdf.sidebarViewOnLoad` setting (None, Thumbnails, Outline, Attachments, Layers, or restore previous state)
- **#13** — Block Ctrl+P / Cmd+P before pdf.js can call `window.print()`
- **#21** — Fix crash handler: only replace the viewer on load-time errors, not post-load runtime errors like the one triggered by dragging text

## Test plan

- [ ] Set `pdf.defaultZoomValue` to `page-width` and open a PDF — verify it opens at that zoom
- [ ] Set `pdf.sidebarViewOnLoad` to `2` and open a PDF — verify the outline panel opens
- [ ] Press Ctrl+P / Cmd+P with a PDF open — verify no print dialog appears
- [ ] Select text in a PDF and drag it — verify the viewer stays intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)