### PR TITLE
fix(security): validate webview message origin

### DIFF
--- a/assets/main.mjs
+++ b/assets/main.mjs
@@ -60,6 +60,10 @@ void (async () => {
 })();
 
 window.addEventListener("message", async (event) => {
+  if (event.origin !== window.origin) {
+    return;
+  }
+
   await window.PDFViewerApplication.initializedPromise;
   const currentPageNumber = window.PDFViewerApplication.pdfViewer.currentPageNumber;
   switch (event.data.action) {

--- a/tools/check_pdfjs.mjs
+++ b/tools/check_pdfjs.mjs
@@ -48,6 +48,7 @@ for (const snippet of [
 ]) {
   assert.ok(patch.includes(snippet), `Missing link guard: ${snippet}`);
 }
+assert.ok(main.includes("event.origin !== window.origin"), "Missing message origin guard");
 for (const snippet of ["targetUrl.origin", "resourceRootUrl.pathname", "Uri.joinPath"]) {
   assert.ok(provider.includes(snippet), `Missing message guard: ${snippet}`);
 }


### PR DESCRIPTION
## Summary

- reject webview messages from any origin other than the current VS Code webview origin
- keep the PDF.js integration self-check covering the message boundary

## Validation

- `pnpm run check`
- `hk check --all --slow`