### PR TITLE
fix: require matching VS Code API version

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "packageManager": "pnpm@11.24.0+sha512.bd27e345e976dcb0be0b7a1228217b049a817e21b1f355c90dbe7dc46671895a8bc1e6d06c24554505ea93ea0b45f489a27ec1bfbc8de6a9659fca0f16fa0000",
   "engines": {
-    "vscode": "^1.95.0"
+    "vscode": "^1.134.0"
   },
   "icon": "icon.png"
 }


### PR DESCRIPTION
The release package step rejects @types/vscode 1.134.0 while engines.vscode remains at ^1.95.0.

Raise the extension engine floor to ^1.134.0 so the manifest matches the current API dependency and VSCE can package the extension.

Verified:
- `mise exec -- hk check --all --slow`
- `pnpm exec vsce package --no-dependencies`