### PR TITLE
fix: wait for PDF pages before fragment navigation

### DIFF
--- a/assets/main.mjs
+++ b/assets/main.mjs
@@ -53,6 +53,7 @@ document.addEventListener(
 void (async () => {
   await window.PDFViewerApplication.initializedPromise;
   await window.PDFViewerApplication.open(config);
+  await window.PDFViewerApplication.pdfViewer.pagesPromise;
   const [, hash] = config.url.split("#");
   if (hash) {
     window.PDFViewerApplication.pdfLinkService.setHash(decodeURIComponent(hash));

--- a/tools/check_pdfjs.mjs
+++ b/tools/check_pdfjs.mjs
@@ -49,6 +49,13 @@ for (const snippet of [
   assert.ok(patch.includes(snippet), `Missing link guard: ${snippet}`);
 }
 assert.ok(main.includes("event.origin !== window.origin"), "Missing message origin guard");
+const initialOpen = main.indexOf("PDFViewerApplication.open(config)");
+const pagesReady = main.indexOf("pdfViewer.pagesPromise");
+const fragmentApplied = main.indexOf("pdfLinkService.setHash");
+assert.ok(
+  initialOpen !== -1 && initialOpen < pagesReady && pagesReady < fragmentApplied,
+  "PDF fragment applied before pages are ready",
+);
 for (const snippet of ["targetUrl.origin", "resourceRootUrl.pathname", "Uri.joinPath"]) {
   assert.ok(provider.includes(snippet), `Missing message guard: ${snippet}`);
 }


### PR DESCRIPTION
## Summary

- wait for pdfViewer.pagesPromise before applying initial page fragments
- add an ordering regression check to the existing PDF.js verifier

Implements https://github.com/mathematic-inc/vscode-pdf/discussions/60.
Thanks @MarkmanGilad for reporting the race and validating the fix.

## Validation

- pnpm run package
- pnpm run typecheck
- repository pre-push checks
- pnpm audit --audit-level high