### PR TITLE
fix: avoid delayed PDF worker startup

### DIFF
--- a/assets/main.mjs
+++ b/assets/main.mjs
@@ -30,7 +30,6 @@ PDFViewerApplicationOptions.set("defaultUrl", "");
 PDFViewerApplicationOptions.set("disablePreferences", true);
 PDFViewerApplicationOptions.set("defaultZoomValue", config.defaultZoomValue ?? "auto");
 PDFViewerApplicationOptions.set("sidebarViewOnLoad", config.sidebarViewOnLoad ?? 0);
-PDFViewerApplicationOptions.set("workerSrc", config.workerSrc);
 PDFViewerApplicationOptions.set("sandboxBundleSrc", config.sandboxBundleSrc);
 PDFViewerApplicationOptions.set("cMapUrl", config.cMapUrl);
 PDFViewerApplicationOptions.set("iccUrl", config.iccUrl);

--- a/src/pdf-viewer-provider.ts
+++ b/src/pdf-viewer-provider.ts
@@ -165,7 +165,6 @@ export class PDFViewerProvider implements CustomReadonlyEditorProvider {
       resourceRoot: withTrailingSlash(webview.asWebviewUri(resourceRoot)),
       defaultZoomValue: config.get<string>("defaultZoomValue", "auto"),
       sidebarViewOnLoad: config.get<number>("sidebarViewOnLoad", 0),
-      workerSrc: `${resolvePdfJsURI("build", "pdf.worker.mjs")}`,
       sandboxBundleSrc: `${resolvePdfJsURI("build", "pdf.sandbox.mjs")}`,
       cMapUrl: withTrailingSlash(resolvePdfJsURI("web", "cmaps")),
       iccUrl: withTrailingSlash(resolvePdfJsURI("web", "iccs")),

--- a/tools/check_pdfjs.mjs
+++ b/tools/check_pdfjs.mjs
@@ -26,7 +26,6 @@ for (const tag of [
 }
 
 const assets = new Map([
-  ["workerSrc", "assets/pdf.js/build/pdf.worker.mjs"],
   ["sandboxBundleSrc", "assets/pdf.js/build/pdf.sandbox.mjs"],
   ["cMapUrl", "assets/pdf.js/web/cmaps/LICENSE"],
   ["iccUrl", "assets/pdf.js/web/iccs/CGATS001Compat-v2-micro.icc"],
@@ -40,6 +39,12 @@ for (const [option, path] of assets) {
   assert.ok(main.includes(`set("${option}"`), `Missing viewer option: ${option}`);
   assert.ok(existsSync(join(root, path)), `Missing PDF.js asset: ${path}`);
 }
+assert.ok(existsSync(join(root, "assets/pdf.js/build/pdf.worker.mjs")), "Missing PDF.js worker");
+assert.ok(
+  !main.includes('set("workerSrc"'),
+  "Absolute workerSrc triggers a 30-second webview delay",
+);
+assert.ok(!provider.includes("workerSrc:"), "Do not override PDF.js's relative workerSrc");
 
 for (const snippet of [
   "super.addLinkAttributes(link, url, newWindow)",


### PR DESCRIPTION
## Summary

- keep the PDF.js worker URL relative so VS Code can start it without a cross-origin blob wrapper
- remove the unused absolute worker configuration
- prevent the delayed worker setup from being reintroduced

Addresses https://github.com/mathematic-inc/vscode-pdf/discussions/63.

## Validation

- reproduced in a VS Code extension development host
- worker request start: 30,048 ms before, 31 ms after
- pnpm run typecheck
- pnpm run check:pdfjs
- oxlint on the repository
- oxfmt on changed files
- pnpm run build