### PR TITLE
feat: add one-time nonprofit support prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,9 @@
       }
     ]
   },
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "devDependencies": {
     "@types/node": "26.4.0",
     "@types/vscode": "1.134.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
-import type { ExtensionContext } from "vscode";
+import { env, type ExtensionContext, Uri, window } from "vscode";
 
 import { PDFViewerProvider } from "./pdf-viewer-provider";
 
 export function activate(context: ExtensionContext): void {
+  if (!context.globalState.get<boolean>("supportPromptShown")) {
+    void context.globalState.update("supportPromptShown", true);
+    void window
+      .showInformationMessage(
+        "Mathematic is a 501(c)(3) non-profit. Please consider supporting our free, open-source work.",
+        "Support Mathematic",
+      )
+      .then((selection) => {
+        if (selection === "Support Mathematic") {
+          void env.openExternal(Uri.parse("https://github.com/sponsors/mathematic-inc"));
+        }
+      });
+  }
+
   context.subscriptions.push(PDFViewerProvider.register(context));
 }
 


### PR DESCRIPTION
Summary

- activate after startup and show a one-time support prompt per VS Code profile
- open the existing Mathematic GitHub Sponsors page when the CTA is selected

Checks

- pnpm package
- hk check --all --slow
- GitHub CI and CodeQL