### PR TITLE
fix(ci): harden release workflows and repository checks

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -4,51 +4,33 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v0.1.0)"
+        description: Existing release tag
         required: true
         type: string
 
 concurrency:
-  group: release-notes-${{ github.event.inputs.tag }}
-  cancel-in-progress: true
+  group: release-notes-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   enhance:
-    name: Enhance release notes with Claude
+    name: Update release notes
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
+    environment: release
     permissions:
       contents: write
-      id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Write release notes with Claude
-        uses: anthropics/claude-code-action@e8c2d7c16c018cf1e694711c1c07a5f5db2b5eb1 # v1.0.208
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write"
-          prompt: |
-            Write an exciting, polished GitHub release body for vscode-pdf ${{ inputs.tag }} and save it to `release-notes.md`.
-
-            vscode-pdf is a VS Code extension that renders PDF files directly in the editor, powered by PDF.js. It provides a fast, integrated PDF viewing experience without leaving VS Code.
-
-            Steps:
-            1. Run `git describe --tags --abbrev=0 HEAD^` to get the previous tag, then run `git log <previous-tag>..HEAD --oneline` to see all commits in this release.
-            2. Read `src/` source files and `README.md` to understand the extension's features.
-            3. Write the release body to `release-notes.md`. It should:
-               - Open with an enthusiastic one-paragraph summary of what's new or why this release is exciting.
-               - Have clearly labelled sections (e.g. **✨ New Features**, **🐛 Bug Fixes**, **⚡ Improvements**) — only include sections that actually have content.
-               - End with an installation note pointing to the VS Code Marketplace.
-               - Be written in an upbeat, developer-friendly tone — celebrate the work!
-            Do NOT publish it yourself — a subsequent step will do that.
-
-      - name: Publish release notes
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ inputs.tag }}
-          body_path: release-notes.md
+      - name: Generate notes for the existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          gh release view "$RELEASE_TAG" --repo "$GH_REPO" >/dev/null
+          gh api --method POST "repos/$GH_REPO/releases/generate-notes" \
+            -f tag_name="$RELEASE_TAG" --jq .body > release-notes.md
+          gh release edit "$RELEASE_TAG" --repo "$GH_REPO" --notes-file release-notes.md

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,11 +5,14 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
+    environment: release
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,22 +110,21 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          package-manager-cache: false
       - name: Download release assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-assets
           path: dist
-      - name: Find VSIX file
-        id: find-vsix
-        run: echo "path=$(ls dist/*.vsix)" >> "$GITHUB_OUTPUT"
       - name: Publish to Open VSX
-        uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2.0.0
-        with:
-          pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          extensionFile: ${{ steps.find-vsix.outputs.path }}
+        env:
+          OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
+        run: npx --yes ovsx@1.1.1 publish dist/*.vsix
       - name: Publish to VS Marketplace
-        uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2.0.0
-        with:
-          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
-          registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ steps.find-vsix.outputs.path }}
+        env:
+          VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+        run: npx --yes @vscode/vsce@3.9.2 publish --packagePath dist/*.vsix


### PR DESCRIPTION
Replace the deprecated Node 20 publishing action with pinned Open VSX and VS Code marketplace CLIs on Node 24. Protect release automation with the release environment and use GitHub's native release-note API.

Validation: actionlint passed locally. CI, Analyze (actions), Check, Analyze (javascript-typescript), CodeQL all passed in GitHub at commit 383ccf918b9d9aac242a575f27e82f52f7f204c6.
